### PR TITLE
fix #5 #6 postboxの設定に応じてpostの表示を切り替える postの投稿日時を表示する

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -9,7 +9,6 @@ class PostsController < ApplicationController
     @postbox = Postbox.find_by(uid: params[:uid])
     @post = @postbox.posts.build(post_prams)
     if @post.save
-      flash[:success] = "登録が完了しました！"
       redirect_to postbox_path(@postbox.uid), notice: "投稿しました"
     else
       render "new"

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,4 +1,9 @@
 # frozen_string_literal: true
 
 module ApplicationHelper
+  def page_title
+    title = "AnoPost"
+    title = @page_title + " | " + title if @page_title
+    title
+  end
 end

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -1,8 +1,7 @@
 doctype html
 html
   head
-    title
-      | Anopost
+    title = page_title
     = csrf_meta_tags
     = csp_meta_tag
     = stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload'

--- a/app/views/postboxes/show.html.slim
+++ b/app/views/postboxes/show.html.slim
@@ -1,5 +1,14 @@
+- @page_title = @postbox.title
+
 p = @postbox.title
 p = @postbox.description
+- if @postbox.is_published
+  p この投書箱に投稿した内容はURLを知っているすべての利用者が閲覧することができます。
+- else
+  p この投書箱に投稿した内容は管理者のみが閲覧することができます。
 = render "/posts/form", from: :new, url: posts_path(uid: @postbox.uid), post: @post
-- @postbox.posts.each do |post|
-  p = post.content
+- if @postbox.is_published
+  p 投稿一覧
+  - @postbox.posts.each do |post|
+    p = post.content
+    p = post.created_at

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -3,5 +3,5 @@
 require "test_helper"
 
 class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
-  driven_by :selenium, using: :chrome, screen_size: [1400, 1400]
+  driven_by :selenium, using: :headless_chrome
 end

--- a/test/fixtures/postboxes.yml
+++ b/test/fixtures/postboxes.yml
@@ -4,3 +4,17 @@ postbox_1:
   title: テストのポストボックス
   description: このポストボックスはテスト用です。
   is_published: false
+
+published_postbox:
+  id: 100
+  uid: D7apaq6Rb7iv64YjOE0Ay84zTNo
+  title: テストのポストボックス
+  description: このポストボックスはテスト用です。
+  is_published: true
+
+unpublished_postbox:
+  id: 101
+  uid: D7apaq6Rb7iv64YjOE0Ay84zTN0
+  title: テストのポストボックス
+  description: このポストボックスはテスト用です。
+  is_published: false

--- a/test/system/postboxes_test.rb
+++ b/test/system/postboxes_test.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require "application_system_test_case"
+
+class PostboxesTest < ApplicationSystemTestCase
+  test "投書箱作成ページが正しく表示されるか" do
+    visit root_path
+    assert_equal "AnoPost", title
+  end
+
+  test "投書箱が正しく作成できるか" do
+    visit root_path
+    fill_in "postbox_title", with: "投書箱のタイトル"
+    fill_in "postbox_description", with: "投書箱の説明テキスト"
+    click_button "作成"
+    assert_text "投書箱のタイトルを作成しました"
+  end
+end

--- a/test/system/posts_test.rb
+++ b/test/system/posts_test.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require "application_system_test_case"
+
+class PostsTest < ApplicationSystemTestCase
+  test "投稿が正しくできるか" do
+    visit "/postboxes/#{postboxes(:postbox_1).uid}"
+    fill_in "content", with: "投稿する内容"
+    click_button "作成"
+    assert_text "投稿しました"
+  end
+
+  test "公開されてる投書箱の投稿が表示されるか" do
+    visit "/postboxes/#{postboxes(:published_postbox).uid}"
+    fill_in "content", with: "この投稿内容は表示されます"
+    click_button "作成"
+    assert_text "この投稿内容は表示されます"
+  end
+
+  test "公開されない投書箱の投稿が表示されないか" do
+    visit "/postboxes/#{postboxes(:unpublished_postbox).uid}"
+    fill_in "content", with: "この投稿内容は表示されません"
+    click_button "作成"
+    assert_no_text "この投稿内容は表示されまません"
+  end
+end


### PR DESCRIPTION
postboxのis_published属性に応じてpostの表示非表示を切り替える機能を追加
postの投稿日時を表示する機能を追加